### PR TITLE
chore: remove actions on push

### DIFF
--- a/.github/workflows/test-guice.yml
+++ b/.github/workflows/test-guice.yml
@@ -1,8 +1,6 @@
 name: Test snake-guice
 
 on:
-  push:
-    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
The main branch is now protected and can no longer receive a push
without a pull request.