### PR TITLE
fix: run the tests on different versions of Python

### DIFF
--- a/.github/workflows/test-guice.yml
+++ b/.github/workflows/test-guice.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.9", "3.8", "3.7"]
+        python-version: ["3.10", "3.9", "3.8"]
         poetry-version: [""]
         #poetry-version: ["1.1.14", "1.2.0b3"]
 
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.local
-          key: poetry-${{ matrix.poetry-version }}-0
+          key: poetry-${{ matrix.poetry-version }}-1
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
@@ -35,12 +35,18 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
+      - name: Print Python version
+        run: python --version
+
+      - name: Print Poetry version
+        run: poetry --version
+
       - name: Setup dependency cache
         id: dep-cache
         uses: actions/cache@v2
         with:
           path: .venv
-          key: poetry-${{ hashFiles('**/poetry.lock') }}
+          key: poetry-${{ hashFiles('**/poetry.lock') }}-1
 
       - name: Install dependencies
         run: poetry install --no-interaction --no-root

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 Sphinx = {version = "^5.1.1", optional = true, extras = ["docs"]}
 reno = {version = "^3.5.0", optional = true, extras = ["docs"]}
 myst-parser = {version = "^0.18.0", optional = true, extras = ["docs"]}


### PR DESCRIPTION
For some reason the GitHub action I was using just kept installing
Poetry on Python 3.8. This new action seems to work better. I'll have to
go back later and dig in to find out what was happening.